### PR TITLE
CSS: 오늘의카드 - 카드 제목이 2줄 이상일 때 아이콘 or 글자 위치 처리 (width: 360px)

### DIFF
--- a/src/main/frontend/src/components/TodaysCard/CardItem.jsx
+++ b/src/main/frontend/src/components/TodaysCard/CardItem.jsx
@@ -10,10 +10,10 @@ export default function CardItem({ item }) {
 
   return (
     <div className="flex flex-col justify-between w-full h-full">
-      <div className="flex items-center text-base leading-150 font-semibold text-brand md:text-lg xl:text-xl">
+      <div className="flex text-base leading-150 font-semibold text-brand md:text-lg xl:text-xl">
         {titleIcon && (
           <img
-            className="h-5 md:h-6"
+            className="h-5 mt-[1px] md:h-6"
             src={getWeatherImages("cardIcon", name)}
             alt={name}
           />


### PR DESCRIPTION
CSS
- 오늘의 카드: 반응형 디자인에 의해 미세먼지, 일출/일몰 카드의 제목이 2줄 이상이 될 때 제목의 아이콘 or 글자의 위치를 조정 (width: 360px)